### PR TITLE
Update Dockerfile to use eclipse-temurin:17-jre-jammy for runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ RUN mvn dependency:go-offline -B
 COPY src ./src
 RUN mvn clean package -DskipTests -B
 
-FROM eclipse-temurin:17-jre-slim
+# Stage 2: Runtime image
+FROM eclipse-temurin:17-jre-jammy
 
 WORKDIR /app
 
@@ -23,3 +24,4 @@ RUN chmod +x /app/entrypoint.sh
 WORKDIR /config
 
 ENTRYPOINT ["/app/entrypoint.sh"]
+


### PR DESCRIPTION
This pull request makes a minor update to the `Dockerfile` to improve the base runtime image and includes a small formatting change.

- Docker image improvement:
  * Changed the runtime base image from `eclipse-temurin:17-jre-slim` to `eclipse-temurin:17-jre-jammy` for potentially better compatibility and security updates.

- Formatting:
  * Added a newline at the end of the `Dockerfile` for improved formatting and compliance with POSIX standards.