### PR TITLE
Enhance make-release.yml to handle version changes more gracefully

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -81,9 +81,19 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Stage whatever the version plugin changed
           git add pom.xml
+
+          # If nothing is staged, don't fail the workflow
+          if git diff --cached --quiet; then
+            echo "No version changes to commit (pom.xml already at ${{ github.event.inputs.version_number }})."
+            exit 0
+          fi
+
           git commit -m "chore: bump version to ${{ github.event.inputs.version_number }}"
           git push
+
 
       - name: Set release SHA output
         id: set-release-sha


### PR DESCRIPTION
## This pull request...
  - [x] Workflow improvement

## Description
Enhances the make-release workflow to gracefully handle cases where the version is already set to the target version, preventing workflow failures when no version changes are needed.

## Purpose
Previously, if the pom.xml version was already at the target version, the workflow would fail when attempting to commit version changes. 

This update adds a check to skip the commit step if no changes are detected, making the workflow more robust for re-running releases or when the version is already correct.

