### PR TITLE
Fix YouTube source playback clients

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -277,11 +277,11 @@
             <artifactId>lavaplayer</artifactId>
             <version>${lavaplayer.version}</version>
         </dependency>
-        <!-- YouTube Source Fork Dependency -->
+        <!-- YouTube Source Dependency -->
         <dependency>
-            <groupId>com.github.arif-banai.youtube-source</groupId>
-            <artifactId>common</artifactId>
-            <version>5512253</version>
+            <groupId>dev.lavalink.youtube</groupId>
+            <artifactId>v2</artifactId>
+            <version>${youtube-source.version}</version>
         </dependency>
         <!-- Dropping JLyrics since it is not being maintained / not working anymore -->
         <!-- <dependency>
@@ -563,7 +563,7 @@
         <jdave.version>0.1.5</jdave.version>
         <udpqueue.version>0.2.12</udpqueue.version>
         <lavaplayer.version>2.2.6</lavaplayer.version>
-        <youtube-source.version>1.16.0</youtube-source.version>
+        <youtube-source.version>1.18.1</youtube-source.version>
         <logback.version>1.5.25</logback.version>
         <typesafe-config.version>1.4.3</typesafe-config.version>
         <jsoup.version>1.22.1</jsoup.version>

--- a/src/main/java/com/jagrosh/jmusicbot/audio/AudioSource.java
+++ b/src/main/java/com/jagrosh/jmusicbot/audio/AudioSource.java
@@ -36,10 +36,9 @@ import com.sedmelluq.discord.lavaplayer.source.vimeo.VimeoAudioSourceManager;
 import dev.lavalink.youtube.YoutubeAudioSourceManager;
 import dev.lavalink.youtube.YoutubeSourceOptions;
 import dev.lavalink.youtube.clients.AndroidVr;
-import dev.lavalink.youtube.clients.ClientOptions;
 import dev.lavalink.youtube.clients.MWeb;
 import dev.lavalink.youtube.clients.Tv;
-import dev.lavalink.youtube.clients.TvHtml5Embedded;
+import dev.lavalink.youtube.clients.TvHtml5Simply;
 import dev.lavalink.youtube.clients.Web;
 import dev.lavalink.youtube.clients.skeleton.Client;
 import org.slf4j.Logger;
@@ -270,34 +269,28 @@ public enum AudioSource
      * 
      * <p>When OAuth is enabled, we use a combination of clients:
      * <ul>
-     *   <li><b>Web (metadata-only)</b> - Primary client for loading video metadata (direct URLs,
-     *       search, playlists). Configured with {@code playback = false} so it won't be used
-     *       for streaming. Being non-embedded, it can handle videos that reject embedded context
-     *       with "video unavailable" errors.</li>
-     *   <li><b>TvHtml5Embedded</b> - OAuth-compatible fallback for loading, primary for streaming.
-     *       Uses embedded player context which works for most videos.</li>
+     *   <li><b>AndroidVr, MWeb, Web</b> - Primary clients for loading and playback.
+     *       These clients can often play public videos without OAuth while the TV OAuth
+     *       client remains available for videos that need account context.</li>
+     *   <li><b>TvHtml5Simply</b> - fallback for loading and primary streaming client.
+     *       Replaces the retired TVHTML5 embedded client.</li>
      *   <li><b>Tv</b> - OAuth-compatible streaming-only client. Used as fallback for loading
      *       audio stream formats during playback.</li>
      * </ul>
      * 
-     * <p>The key insight: OAuth is only required for streaming (getting playback URLs), not for
-     * loading metadata. So we can use the non-OAuth Web client for metadata loading (with
-     * playback disabled) and OAuth clients for streaming.
+     * <p>Keep non-OAuth-capable playback clients enabled even in OAuth mode. If OAuth has
+     * not been authorised yet, disabling these clients forces every playback attempt through
+     * TV clients and makes common "Sign in to confirm you're not a bot" failures more likely.
      */
     private static Client[] buildYoutubeClients(boolean useOauth)
     {
         if (useOauth)
         {
-            // Clients configured for metadata loading only (no playback/streaming)
-            // This handles direct URLs without embedded player restrictions
-            ClientOptions metadataOnly = new ClientOptions();
-            metadataOnly.setPlayback(false);
-            
             return new Client[] { 
-                new AndroidVr(metadataOnly), // metadata loading (non-embedded, non-OAuth)
-                new MWeb(metadataOnly),      // metadata loading (non-embedded, non-OAuth)
-                new Web(metadataOnly),       // metadata loading (non-embedded, non-OAuth)
-                new TvHtml5Embedded(),       // Fallback: loading + primary streaming (OAuth)
+                new AndroidVr(),            // loading + playback (non-embedded, non-OAuth)
+                new MWeb(),                 // loading + playback (non-embedded, non-OAuth)
+                new Web(),                  // loading + playback (non-embedded, non-OAuth)
+                new TvHtml5Simply(),         // Fallback: loading + primary streaming
                 new Tv()                     // Fallback: streaming only (OAuth)
             };
         }

--- a/src/test/java/com/jagrosh/jmusicbot/unit/AudioSourceOAuthTest.java
+++ b/src/test/java/com/jagrosh/jmusicbot/unit/AudioSourceOAuthTest.java
@@ -217,19 +217,19 @@ class AudioSourceOAuthTest {
             // With OAuth enabled
             Object[] oauthClients = (Object[]) buildClients.invoke(null, true);
             assertNotNull(oauthClients, "Should return clients for OAuth mode");
-            assertEquals(5, oauthClients.length, "OAuth mode should use 5 clients (3 metadata-only: AndroidVr, MWeb, Web; 2 OAuth: TvHtml5Embedded, Tv)");
+            assertEquals(5, oauthClients.length, "OAuth mode should use 5 clients (AndroidVr, MWeb, Web, TvHtml5Simply, Tv)");
             
-            // Verify client types - first 3 are metadata-only (playback disabled)
+            // Verify client types - first 3 are regular loading/playback clients
             assertEquals("AndroidVr", oauthClients[0].getClass().getSimpleName(),
-                "First OAuth client should be AndroidVr (metadata-only)");
+                "First OAuth client should be AndroidVr");
             assertEquals("MWeb", oauthClients[1].getClass().getSimpleName(),
-                "Second OAuth client should be MWeb (metadata-only)");
+                "Second OAuth client should be MWeb");
             assertEquals("Web", oauthClients[2].getClass().getSimpleName(),
-                "Third OAuth client should be Web (metadata-only)");
+                "Third OAuth client should be Web");
             
-            // Last 2 are OAuth clients for streaming
-            assertEquals("TvHtml5Embedded", oauthClients[3].getClass().getSimpleName(),
-                "Fourth OAuth client should be TvHtml5Embedded (OAuth streaming)");
+            // Last 2 are fallback/TV clients for streaming
+            assertEquals("TvHtml5Simply", oauthClients[3].getClass().getSimpleName(),
+                "Fourth OAuth client should be TvHtml5Simply (fallback streaming)");
             assertEquals("Tv", oauthClients[4].getClass().getSimpleName(),
                 "Fifth OAuth client should be Tv (OAuth streaming)");
         }


### PR DESCRIPTION
### This pull request...
  - [x] Fixes a bug
  - [ ] Introduces a new feature
  - [ ] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
Updates the YouTube source dependency and playback client configuration to avoid playback failures caused by the retired TVHTML5 embedded client.

This switches YouTube playback to the official `dev.lavalink.youtube:v2` artifact, updates `youtube-source` to `1.18.1`, replaces `TvHtml5Embedded` with `TvHtml5Simply`, and keeps the regular `AndroidVr`, `MWeb`, and `Web` clients enabled for playback when OAuth is enabled.

### Purpose
YouTube playback can fail with `AllClientsFailedException` because the previous TVHTML5 embedded client is no longer supported by YouTube. When OAuth is enabled, disabling the regular playback clients also forces playback through TV clients only, which makes `Sign in to confirm you're not a bot` and login-required failures more likely.

This change updates the YouTube source/client configuration so public videos can still use regular playback clients, while TV/OAuth-capable clients remain available as fallbacks for videos that need account context.

### Relevant Issue(s)
No linked issue.
