### PR TITLE
fix: update youtube-source to 1.18.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -587,7 +587,7 @@
         <jdave.version>0.1.7</jdave.version>
         <udpqueue.version>0.2.12</udpqueue.version>
         <lavaplayer.version>2.2.7</lavaplayer.version>
-        <youtube-source.version>1.18.1</youtube-source.version>
+        <youtube-source.version>1.18.2</youtube-source.version>
         <logback.version>1.5.25</logback.version>
         <typesafe-config.version>1.4.3</typesafe-config.version>
         <jsoup.version>1.22.1</jsoup.version>


### PR DESCRIPTION
### This pull request...
- [x] Fixes a bug
- [ ] Introduces a new feature
- [ ] Improves an existing feature
- [ ] Boosts code quality or performance

### Description
With YouTube OAuth enabled, playback of some long-form YouTube tracks fails after metadata loads. The failure occurs while `YoutubeAudioTrack` processes the legacy `itag 18` stream:

```text
java.io.EOFException
    at ...MpegFileLoader.parseHeaders(...)
    at ...YoutubeAudioTrack.processStatic(...)
```

The fallback `TVHTML5_SIMPLY` client may then return `Sign in to confirm you're not a bot`, even though the OAuth access token refreshed successfully.

### Change
Update `dev.lavalink.youtube:v2` from youtube-source `1.18.1` to `1.18.2`.

This is intentionally a dependency-only change. No user configuration, tokens, or authentication data are included.

### Validation
- `mvn test` — 664 tests passed, 0 failures, 0 errors.
- `mvn -DskipTests package` — build succeeded.
- youtube-source `1.18.2` includes the fix for playback of format `itag 18`.

### Related
This supersedes the snapshot dependency used by PR #66.