### PR TITLE
fix: enable YouTube playback fallbacks for long tracks

### DIFF
--- a/src/main/java/com/jagrosh/jmusicbot/audio/AudioSource.java
+++ b/src/main/java/com/jagrosh/jmusicbot/audio/AudioSource.java
@@ -36,7 +36,6 @@ import com.sedmelluq.discord.lavaplayer.source.vimeo.VimeoAudioSourceManager;
 import dev.lavalink.youtube.YoutubeAudioSourceManager;
 import dev.lavalink.youtube.YoutubeSourceOptions;
 import dev.lavalink.youtube.clients.AndroidVrWithThumbnail;
-import dev.lavalink.youtube.clients.ClientOptions;
 import dev.lavalink.youtube.clients.MWebWithThumbnail;
 import dev.lavalink.youtube.clients.Tv;
 import dev.lavalink.youtube.clients.TvHtml5SimplyWithThumbnail;
@@ -268,13 +267,11 @@ public enum AudioSource
      * 
      * <p>When OAuth is enabled, we use a combination of clients:
      * <ul>
-     *   <li><b>AndroidVrWithThumbnail</b> - Metadata loading (non-embedded, non-OAuth)</li>
-     *   <li><b>MWebWithThumbnail</b> - Metadata loading (non-embedded, non-OAuth)</li>
-     *   <li><b>Web</b> - Metadata loading (non-embedded, non-OAuth)</li>
-     *   <li><b>Tv</b> - OAuth-compatible streaming-only client. Used as fallback for loading
-     *       audio stream formats during playback.</li>
-     *   <li><b>TvHtml5SimplyWithThumbnail</b> - *Not oAuth compatible* Used as fallback for loading
-     *       audio stream formats during playback.</li>
+     *   <li><b>AndroidVrWithThumbnail</b> - Non-embedded playback fallback with Opus support.</li>
+     *   <li><b>MWebWithThumbnail</b> - Non-embedded playback fallback.</li>
+     *   <li><b>WebWithThumbnail</b> - Non-embedded playback fallback.</li>
+     *   <li><b>Tv</b> - OAuth-compatible playback client.</li>
+     *   <li><b>TvHtml5SimplyWithThumbnail</b> - Non-OAuth playback fallback.</li>
      * </ul>
      * 
      * <p>
@@ -283,17 +280,12 @@ public enum AudioSource
     {
         if (useOauth)
         {
-            // Clients configured for metadata loading only (no playback/streaming)
-            // This handles direct URLs without embedded player restrictions
-            ClientOptions metadataOnly = new ClientOptions();
-            metadataOnly.setPlayback(false);
-            
             return new Client[] {
-                new AndroidVrWithThumbnail(metadataOnly), // metadata loading (non-embedded, non-OAuth)
-                new MWebWithThumbnail(metadataOnly),      // metadata loading (non-embedded, non-OAuth)
-                new WebWithThumbnail(metadataOnly),       // metadata loading (non-embedded, non-OAuth)
-                new Tv(),
-                new TvHtml5SimplyWithThumbnail()
+                new AndroidVrWithThumbnail(),       // audio-capable fallback for long-form playback
+                new MWebWithThumbnail(),            // audio-capable fallback for long-form playback
+                new WebWithThumbnail(),             // audio-capable fallback for long-form playback
+                new Tv(),                            // OAuth-compatible playback
+                new TvHtml5SimplyWithThumbnail()     // non-OAuth playback fallback
             };
         }
         // Clients are required even without OAuth to properly handle YouTube URLs

--- a/src/test/java/com/jagrosh/jmusicbot/unit/AudioSourceOAuthTest.java
+++ b/src/test/java/com/jagrosh/jmusicbot/unit/AudioSourceOAuthTest.java
@@ -245,11 +245,11 @@ class AudioSourceOAuthTest {
                 "Fourth OAuth client should be Tv");
             assertEquals("TvHtml5SimplyWithThumbnail", oauthClients[4].getClass().getSimpleName(),
                 "Fifth OAuth client should be TvHtml5SimplyWithThumbnail");
-            // Verify first 3 clients have playback disabled (metadataOnly)
+            // Verify all OAuth-mode clients remain eligible for playback fallback.
             for (int i = 0; i < 3; i++) {
                 Client client = (Client) oauthClients[i];
-                assertFalse(client.getOptions().getPlayback(), 
-                    String.format("OAuth client %d (%s) should have playback disabled", 
+                assertTrue(client.getOptions().getPlayback(),
+                    String.format("OAuth client %d (%s) should have playback enabled",
                         i, client.getClass().getSimpleName()));
             }
         }


### PR DESCRIPTION
### This pull request...
- [x] Fixes a bug
- [ ] Introduces a new feature
- [ ] Improves an existing feature
- [ ] Boosts code quality or performance

### Description
When YouTube OAuth was enabled, the Android VR, MWeb, and Web clients were configured for metadata loading only. Long-form tracks could then be forced through the TVHTML5 playback path, which failed for some long videos.

This change keeps the existing OAuth-compatible clients and enables the other audio-capable clients as playback fallbacks.

### Purpose
Short tracks worked, but long-form tracks failed during playback. Allowing the additional clients to participate gives youtube-source more playback options.

### Testing
- All 664 automated tests pass.
- Validated with the live bot using OAuth and a 10-hour YouTube track.

### Notes
This PR contains source and test changes only. No bot configuration, OAuth tokens, or private logs are included.
Related: #71