### PR TITLE
feat: add Bilibili audio source

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This version of JMusicBot changes/updates various dependencies. To ensure your b
   * Smooth playback
   * Server-specific setup for the "DJ" role that can moderate the music
   * Clean and beautiful menus
-  * Supports many sites, including Youtube, Soundcloud, and more
+  * Supports many sites, including Youtube, Soundcloud, Bilibili, and more
   * Supports many online radio/streams
   * Supports local files
   * Playlist support (both web/youtube, and local)
@@ -50,8 +50,22 @@ JMusicBot supports all sources and formats supported by [lavaplayer](https://git
   * Bandcamp
   * Vimeo
   * Twitch streams
+  * Bilibili (哔哩哔哩)
   * Local files
   * HTTP URLs
+
+#### Bilibili
+Paste a Bilibili video link into `play` and the bot queues its audio. Video URLs,
+bare `BV` ids, and `b23.tv` short links all work, and no Bilibili account is needed.
+
+`bilisearch` (alias `bsearch`) searches Bilibili by keyword and offers the results
+for selection, the same way `scsearch` does for SoundCloud.
+
+A multi-page (分P) video always plays exactly one part: the one named by `?p=`, or
+part 1 when the link does not say. It is never expanded into the whole queue.
+
+To turn the source off, set `bilibili = false` under `playback.audioSources`.
+
 ### Formats
   * MP3
   * FLAC

--- a/src/main/java/com/jagrosh/jmusicbot/audio/AudioSource.java
+++ b/src/main/java/com/jagrosh/jmusicbot/audio/AudioSource.java
@@ -46,6 +46,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.jagrosh.jmusicbot.BotConfig;
+import com.jagrosh.jmusicbot.audio.bilibili.BilibiliAudioSourceManager;
 import com.jagrosh.jmusicbot.utils.OtherUtil;
 
 /**
@@ -118,6 +119,12 @@ public enum AudioSource
         "NicoNico videos",
         80,
         (manager, config) -> manager.registerSourceManager(new NicoAudioSourceManager())
+    ),
+    BILIBILI(
+        "bilibili",
+        "Bilibili (哔哩哔哩) videos and search",
+        25,
+        (manager, config) -> manager.registerSourceManager(new BilibiliAudioSourceManager())
     ),
     
     // Catch-all sources (priority 100+) - registered last as fallbacks

--- a/src/main/java/com/jagrosh/jmusicbot/audio/bilibili/BilibiliApiClient.java
+++ b/src/main/java/com/jagrosh/jmusicbot/audio/bilibili/BilibiliApiClient.java
@@ -54,7 +54,11 @@ public class BilibiliApiClient
     private static final Logger LOGGER = LoggerFactory.getLogger(BilibiliApiClient.class);
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
-    private static final String VIEW_URL = "https://api.bilibili.com/x/web-interface/view?";
+    /**
+     * The WBI variant. Bilibili brought the unsigned {@code x/web-interface/view} under
+     * risk control in early September 2026, and it has answered HTTP 412 ever since.
+     */
+    private static final String VIEW_URL = "https://api.bilibili.com/x/web-interface/wbi/view?";
     private static final String PLAYURL_SIGNED = "https://api.bilibili.com/x/player/wbi/playurl?";
     private static final String PLAYURL_PLAIN = "https://api.bilibili.com/x/player/playurl?";
     private static final String SEARCH_URL = "https://api.bilibili.com/x/web-interface/wbi/search/type?";
@@ -76,7 +80,12 @@ public class BilibiliApiClient
      */
     public BilibiliVideo loadVideo(HttpInterface http, String id, int page) throws IOException
     {
-        return BilibiliResponseParser.parseView(getJson(http, VIEW_URL + buildViewQuery(id)), page);
+        String mixinKey = mixinKey(http);
+        String query = mixinKey != null
+                ? buildViewQuery(id, mixinKey, System.currentTimeMillis() / 1000L)
+                : buildUnsignedViewQuery(id);
+
+        return BilibiliResponseParser.parseView(getJson(http, VIEW_URL + query), page);
     }
 
     /**
@@ -144,14 +153,35 @@ public class BilibiliApiClient
     }
 
     /**
-     * Builds the {@code view} query, which identifies a video by {@code aid} or {@code bvid}.
+     * Builds the WBI-signed {@code view} query.
      */
-    public static String buildViewQuery(String id)
+    public static String buildViewQuery(String id, String mixinKey, long wtsSeconds)
     {
-        if(id.regionMatches(true, 0, "av", 0, 2))
-            return "aid=" + encode(id.substring(2));
+        return WbiSigner.sign(viewParams(id), mixinKey, wtsSeconds);
+    }
 
-        return "bvid=" + encode(id);
+    /**
+     * Builds the unsigned {@code view} query used when a signing key is unavailable. The WBI
+     * endpoint still answers without a signature, so this degrades rather than breaks.
+     */
+    public static String buildUnsignedViewQuery(String id)
+    {
+        Map.Entry<String, String> param = viewParams(id).entrySet().iterator().next();
+        return encode(param.getKey()) + "=" + encode(param.getValue());
+    }
+
+    /**
+     * Identifies a video by {@code aid} or {@code bvid}, whichever the id form calls for.
+     */
+    private static Map<String, String> viewParams(String id)
+    {
+        Map<String, String> params = new LinkedHashMap<>();
+        if(id.regionMatches(true, 0, "av", 0, 2))
+            params.put("aid", id.substring(2));
+        else
+            params.put("bvid", id);
+
+        return params;
     }
 
     /**

--- a/src/main/java/com/jagrosh/jmusicbot/audio/bilibili/BilibiliApiClient.java
+++ b/src/main/java/com/jagrosh/jmusicbot/audio/bilibili/BilibiliApiClient.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2026 Arif Banai (arif-banai)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jagrosh.jmusicbot.audio.bilibili;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sedmelluq.discord.lavaplayer.tools.FriendlyException;
+import com.sedmelluq.discord.lavaplayer.tools.io.HttpInterface;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.util.EntityUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Performs the HTTP calls against Bilibili's web API.
+ *
+ * <p>Bilibili's CDN rejects requests that lack a {@code Referer} or that do not present a
+ * browser {@code User-Agent}; both cases return HTTP 403. Those headers are therefore part
+ * of this class's contract rather than an optional nicety.
+ *
+ * @author Arif Banai (arif-banai)
+ */
+public class BilibiliApiClient
+{
+    /** Required by Bilibili's CDN; requests without it are answered with HTTP 403. */
+    public static final String REFERER = "https://www.bilibili.com";
+
+    /** Required by Bilibili's CDN; requests without a browser UA are answered with HTTP 403. */
+    public static final String USER_AGENT =
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+            + "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(BilibiliApiClient.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static final String VIEW_URL = "https://api.bilibili.com/x/web-interface/view?";
+    private static final String PLAYURL_SIGNED = "https://api.bilibili.com/x/player/wbi/playurl?";
+    private static final String PLAYURL_PLAIN = "https://api.bilibili.com/x/player/playurl?";
+    private static final String SEARCH_URL = "https://api.bilibili.com/x/web-interface/wbi/search/type?";
+    private static final String NAV_URL = "https://api.bilibili.com/x/web-interface/nav";
+
+    /** DASH format, which yields an audio-only stream instead of a full video download. */
+    private static final String DASH_PARAMS = "&fnval=16&fnver=0&fourk=1";
+
+    private static final long KEY_TTL_MS = 12L * 60 * 60 * 1000;
+
+    private volatile String cachedMixinKey;
+    private volatile long cachedMixinKeyAt;
+
+    /**
+     * Loads metadata for one page of a video.
+     *
+     * @param id a {@code BV} id or an {@code av} id
+     * @param page the 1-based page number
+     */
+    public BilibiliVideo loadVideo(HttpInterface http, String id, int page) throws IOException
+    {
+        return BilibiliResponseParser.parseView(getJson(http, VIEW_URL + buildViewQuery(id)), page);
+    }
+
+    /**
+     * Resolves a playable audio stream.
+     *
+     * <p>Prefers the WBI-signed endpoint. If the signing key cannot be obtained, falls
+     * back to the unsigned endpoint so playback degrades rather than breaks.
+     *
+     * @param cid the page id, or 0 to look it up from the {@code bvid} first
+     */
+    public BilibiliAudioStream loadAudioStream(HttpInterface http, String bvid, long cid) throws IOException
+    {
+        long pageId = cid;
+        if(pageId <= 0)
+        {
+            // Search results arrive without a cid, so resolve it before asking for a stream.
+            pageId = loadVideo(http, bvid, 1).cid();
+        }
+
+        String mixinKey = mixinKey(http);
+        String url = mixinKey != null
+                ? PLAYURL_SIGNED + buildPlayurlQuery(bvid, pageId, mixinKey, System.currentTimeMillis() / 1000L)
+                : PLAYURL_PLAIN + buildUnsignedPlayurlQuery(bvid, pageId);
+
+        return BilibiliResponseParser.parseAudioStream(getJson(http, url));
+    }
+
+    /**
+     * Searches Bilibili for videos matching the query.
+     *
+     * @param limit the maximum number of results to request
+     */
+    public List<BilibiliVideo> search(HttpInterface http, String query, int limit) throws IOException
+    {
+        String mixinKey = mixinKey(http);
+        if(mixinKey == null)
+            throw new FriendlyException("Bilibili search is unavailable: could not obtain a signing key",
+                    FriendlyException.Severity.SUSPICIOUS, null);
+
+        Map<String, String> params = new LinkedHashMap<>();
+        params.put("search_type", "video");
+        params.put("keyword", query);
+        params.put("page", "1");
+        params.put("page_size", Integer.toString(limit));
+
+        String signed = WbiSigner.sign(params, mixinKey, System.currentTimeMillis() / 1000L);
+        return BilibiliResponseParser.parseSearch(getJson(http, SEARCH_URL + signed));
+    }
+
+    /**
+     * Follows a {@code b23.tv} redirect to the real video URL.
+     *
+     * @return the resolved URL, or the input unchanged if no redirect was recorded
+     */
+    public String resolveShortLink(HttpInterface http, String shortUrl) throws IOException
+    {
+        HttpGet request = new HttpGet(shortUrl);
+        applyHeaders(request);
+
+        try(CloseableHttpResponse response = http.execute(request))
+        {
+            EntityUtils.consumeQuietly(response.getEntity());
+            return http.getFinalLocation() != null ? http.getFinalLocation().toString() : shortUrl;
+        }
+    }
+
+    /**
+     * Builds the {@code view} query, which identifies a video by {@code aid} or {@code bvid}.
+     */
+    public static String buildViewQuery(String id)
+    {
+        if(id.regionMatches(true, 0, "av", 0, 2))
+            return "aid=" + encode(id.substring(2));
+
+        return "bvid=" + encode(id);
+    }
+
+    /**
+     * Builds the WBI-signed {@code playurl} query.
+     */
+    public static String buildPlayurlQuery(String bvid, long cid, String mixinKey, long wtsSeconds)
+    {
+        Map<String, String> params = new LinkedHashMap<>();
+        params.put("bvid", bvid);
+        params.put("cid", Long.toString(cid));
+        params.put("fnval", "16");
+        params.put("fnver", "0");
+        params.put("fourk", "1");
+
+        return WbiSigner.sign(params, mixinKey, wtsSeconds);
+    }
+
+    /**
+     * Builds the unsigned {@code playurl} query used when a signing key is unavailable.
+     */
+    public static String buildUnsignedPlayurlQuery(String bvid, long cid)
+    {
+        return "bvid=" + encode(bvid) + "&cid=" + cid + DASH_PARAMS;
+    }
+
+    /**
+     * Returns the cached mixin key, refreshing it when stale.
+     *
+     * @return the key, or null if it could not be obtained
+     */
+    private String mixinKey(HttpInterface http)
+    {
+        long now = System.currentTimeMillis();
+        String cached = cachedMixinKey;
+        if(cached != null && now - cachedMixinKeyAt < KEY_TTL_MS)
+            return cached;
+
+        try
+        {
+            JsonNode wbi = getJson(http, NAV_URL).path("data").path("wbi_img");
+            String key = WbiSigner.mixinKey(
+                    WbiSigner.keyFromUrl(wbi.path("img_url").asText()),
+                    WbiSigner.keyFromUrl(wbi.path("sub_url").asText()));
+
+            cachedMixinKey = key;
+            cachedMixinKeyAt = now;
+            return key;
+        }
+        catch(Exception e)
+        {
+            LOGGER.warn("Could not fetch Bilibili WBI keys, falling back to unsigned requests: {}",
+                    e.getMessage());
+            return null;
+        }
+    }
+
+    private JsonNode getJson(HttpInterface http, String url) throws IOException
+    {
+        HttpGet request = new HttpGet(url);
+        applyHeaders(request);
+
+        try(CloseableHttpResponse response = http.execute(request))
+        {
+            int status = response.getStatusLine().getStatusCode();
+            if(status != 200)
+                throw new IOException("Bilibili API returned HTTP " + status);
+
+            return MAPPER.readTree(response.getEntity().getContent());
+        }
+    }
+
+    private static void applyHeaders(HttpGet request)
+    {
+        request.setHeader("Referer", REFERER);
+        request.setHeader("User-Agent", USER_AGENT);
+    }
+
+    private static String encode(String value)
+    {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
+    }
+}

--- a/src/main/java/com/jagrosh/jmusicbot/audio/bilibili/BilibiliAudioSourceManager.java
+++ b/src/main/java/com/jagrosh/jmusicbot/audio/bilibili/BilibiliAudioSourceManager.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2026 Arif Banai (arif-banai)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jagrosh.jmusicbot.audio.bilibili;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager;
+import com.sedmelluq.discord.lavaplayer.source.AudioSourceManager;
+import com.sedmelluq.discord.lavaplayer.tools.ExceptionTools;
+import com.sedmelluq.discord.lavaplayer.tools.FriendlyException;
+import com.sedmelluq.discord.lavaplayer.tools.io.HttpClientTools;
+import com.sedmelluq.discord.lavaplayer.tools.io.HttpInterface;
+import com.sedmelluq.discord.lavaplayer.tools.io.HttpInterfaceManager;
+import com.sedmelluq.discord.lavaplayer.track.AudioItem;
+import com.sedmelluq.discord.lavaplayer.track.AudioReference;
+import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
+import com.sedmelluq.discord.lavaplayer.track.AudioTrackInfo;
+import com.sedmelluq.discord.lavaplayer.track.BasicAudioPlaylist;
+import org.apache.http.Header;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.message.BasicHeader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Plays audio from Bilibili (哔哩哔哩) videos.
+ *
+ * <p>Accepts video URLs, bare {@code BV} ids, {@code b23.tv} short links, and
+ * {@code bilisearch:} queries. A multi-page (分P) video always resolves to exactly one
+ * track: the page named by {@code ?p=}, or page 1 when none is given. Expanding every
+ * part into the queue would flood it with content the user did not ask for.
+ *
+ * <p>Works anonymously; no account or cookie is required.
+ *
+ * @author Arif Banai (arif-banai)
+ */
+public class BilibiliAudioSourceManager implements AudioSourceManager
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(BilibiliAudioSourceManager.class);
+
+    private static final String SOURCE_NAME = "bilibili";
+    private static final int SEARCH_LIMIT = 20;
+    private static final String VIDEO_URL_PREFIX = "https://www.bilibili.com/video/";
+
+    private final HttpInterfaceManager httpInterfaceManager;
+    private final BilibiliApiClient apiClient;
+
+    public BilibiliAudioSourceManager()
+    {
+        this.apiClient = new BilibiliApiClient();
+        this.httpInterfaceManager = HttpClientTools.createDefaultThreadLocalManager();
+        this.httpInterfaceManager.configureBuilder(BilibiliAudioSourceManager::configureHeaders);
+    }
+
+    /**
+     * Bilibili's CDN answers 403 unless both a Referer and a browser User-Agent are
+     * present, so they are set as defaults on every request this manager makes.
+     */
+    private static void configureHeaders(HttpClientBuilder builder)
+    {
+        List<Header> headers = new ArrayList<>();
+        headers.add(new BasicHeader("Referer", BilibiliApiClient.REFERER));
+        headers.add(new BasicHeader("User-Agent", BilibiliApiClient.USER_AGENT));
+        builder.setDefaultHeaders(headers);
+    }
+
+    @Override
+    public String getSourceName()
+    {
+        return SOURCE_NAME;
+    }
+
+    /**
+     * Gets an HTTP interface carrying the headers Bilibili requires.
+     */
+    public HttpInterface getHttpInterface()
+    {
+        return httpInterfaceManager.getInterface();
+    }
+
+    public BilibiliApiClient getApiClient()
+    {
+        return apiClient;
+    }
+
+    @Override
+    public AudioItem loadItem(AudioPlayerManager manager, AudioReference reference)
+    {
+        BilibiliLink link = BilibiliLink.parse(reference.identifier);
+        if(link == null)
+            return null;
+
+        try(HttpInterface httpInterface = getHttpInterface())
+        {
+            return switch(link.kind())
+            {
+                case SEARCH -> loadSearch(httpInterface, link.id());
+                case VIDEO -> loadVideo(httpInterface, link.id(), link.page());
+                case SHORT_LINK -> loadShortLink(httpInterface, link.id());
+            };
+        }
+        catch(FriendlyException e)
+        {
+            throw e;
+        }
+        catch(Exception e)
+        {
+            throw ExceptionTools.wrapUnfriendlyExceptions(
+                    "Could not load this Bilibili item.", FriendlyException.Severity.FAULT, e);
+        }
+    }
+
+    private AudioItem loadVideo(HttpInterface httpInterface, String id, int page) throws IOException
+    {
+        return buildTrack(apiClient.loadVideo(httpInterface, id, page));
+    }
+
+    /**
+     * Expands a b23.tv link, then loads whatever it points at. Deliberately does not
+     * recurse further, so a redirect loop cannot hang the bot.
+     */
+    private AudioItem loadShortLink(HttpInterface httpInterface, String shortUrl) throws IOException
+    {
+        String resolved = apiClient.resolveShortLink(httpInterface, shortUrl);
+        BilibiliLink link = BilibiliLink.parse(resolved);
+
+        if(link == null || link.kind() != BilibiliLink.Kind.VIDEO)
+        {
+            LOGGER.debug("b23.tv link {} resolved to unsupported target {}", shortUrl, resolved);
+            return AudioReference.NO_TRACK;
+        }
+        return loadVideo(httpInterface, link.id(), link.page());
+    }
+
+    private AudioItem loadSearch(HttpInterface httpInterface, String query) throws IOException
+    {
+        List<BilibiliVideo> results = apiClient.search(httpInterface, query, SEARCH_LIMIT);
+        if(results.isEmpty())
+            return AudioReference.NO_TRACK;
+
+        List<AudioTrack> tracks = new ArrayList<>(results.size());
+        for(BilibiliVideo video : results)
+            tracks.add(buildTrack(video));
+
+        return new BasicAudioPlaylist("Search results for: " + query, tracks, null, true);
+    }
+
+    /**
+     * Builds a track. Search results carry no cid, so those tracks hold 0 and resolve it
+     * from the bvid when they start playing.
+     */
+    private AudioTrack buildTrack(BilibiliVideo video)
+    {
+        AudioTrackInfo info = new AudioTrackInfo(
+                video.title(),
+                video.author(),
+                video.durationMs(),
+                video.bvid(),
+                false,
+                VIDEO_URL_PREFIX + video.bvid(),
+                video.thumbnailUrl(),
+                null);
+
+        return new BilibiliAudioTrack(info, video.cid(), this);
+    }
+
+    @Override
+    public boolean isTrackEncodable(AudioTrack track)
+    {
+        return true;
+    }
+
+    @Override
+    public void encodeTrack(AudioTrack track, DataOutput output) throws IOException
+    {
+        output.writeLong(((BilibiliAudioTrack) track).getCid());
+    }
+
+    @Override
+    public AudioTrack decodeTrack(AudioTrackInfo trackInfo, DataInput input) throws IOException
+    {
+        return new BilibiliAudioTrack(trackInfo, input.readLong(), this);
+    }
+
+    @Override
+    public void shutdown()
+    {
+        try
+        {
+            httpInterfaceManager.close();
+        }
+        catch(IOException e)
+        {
+            LOGGER.debug("Failed to close the Bilibili HTTP interface manager", e);
+        }
+    }
+}

--- a/src/main/java/com/jagrosh/jmusicbot/audio/bilibili/BilibiliAudioStream.java
+++ b/src/main/java/com/jagrosh/jmusicbot/audio/bilibili/BilibiliAudioStream.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 Arif Banai (arif-banai)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jagrosh.jmusicbot.audio.bilibili;
+
+import java.util.List;
+
+/**
+ * A resolved audio stream.
+ *
+ * <p>These URLs expire roughly 120 minutes after Bilibili issues them, so instances are
+ * short-lived and resolved at playback time rather than when a track is queued.
+ *
+ * @param url the primary CDN URL
+ * @param backupUrls alternate CDN URLs to try if the primary one fails
+ * @param bandwidth the stream bitrate in bits per second, or 0 if unknown
+ *
+ * @author Arif Banai (arif-banai)
+ */
+public record BilibiliAudioStream(String url, List<String> backupUrls, int bandwidth)
+{
+}

--- a/src/main/java/com/jagrosh/jmusicbot/audio/bilibili/BilibiliAudioTrack.java
+++ b/src/main/java/com/jagrosh/jmusicbot/audio/bilibili/BilibiliAudioTrack.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2026 Arif Banai (arif-banai)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jagrosh.jmusicbot.audio.bilibili;
+
+import java.net.URI;
+
+import com.sedmelluq.discord.lavaplayer.container.mpeg.MpegAudioTrack;
+import com.sedmelluq.discord.lavaplayer.source.AudioSourceManager;
+import com.sedmelluq.discord.lavaplayer.tools.io.HttpInterface;
+import com.sedmelluq.discord.lavaplayer.tools.io.PersistentHttpStream;
+import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
+import com.sedmelluq.discord.lavaplayer.track.AudioTrackInfo;
+import com.sedmelluq.discord.lavaplayer.track.DelegatedAudioTrack;
+import com.sedmelluq.discord.lavaplayer.track.playback.LocalAudioTrackExecutor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * One Bilibili video page, played as audio.
+ *
+ * <p>The stream URL is resolved here rather than when the track is queued, because
+ * Bilibili's CDN URLs expire after roughly 120 minutes. A track sitting behind a long
+ * queue would otherwise hold a dead URL by the time it started playing. Resolving late
+ * also means a replay fetches a fresh URL.
+ *
+ * <p>Bilibili serves DASH audio as fragmented MP4 containing AAC, which is the same shape
+ * as YouTube's adaptive formats, so {@link MpegAudioTrack} decodes it directly and no
+ * transcoding is needed.
+ *
+ * @author Arif Banai (arif-banai)
+ */
+public class BilibiliAudioTrack extends DelegatedAudioTrack
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(BilibiliAudioTrack.class);
+
+    private final long cid;
+    private final BilibiliAudioSourceManager sourceManager;
+
+    /**
+     * @param trackInfo standard lavaplayer metadata; {@code identifier} holds the bvid
+     * @param cid the page id, or 0 to resolve it at playback time
+     * @param sourceManager the manager that created this track
+     */
+    public BilibiliAudioTrack(AudioTrackInfo trackInfo, long cid, BilibiliAudioSourceManager sourceManager)
+    {
+        super(trackInfo);
+        this.cid = cid;
+        this.sourceManager = sourceManager;
+    }
+
+    /**
+     * Gets the Bilibili page id backing this track.
+     *
+     * @return the cid, or 0 if it is resolved at playback time
+     */
+    public long getCid()
+    {
+        return cid;
+    }
+
+    @Override
+    public void process(LocalAudioTrackExecutor executor) throws Exception
+    {
+        try(HttpInterface httpInterface = sourceManager.getHttpInterface())
+        {
+            BilibiliAudioStream stream = sourceManager.getApiClient()
+                    .loadAudioStream(httpInterface, trackInfo.identifier, cid);
+
+            LOGGER.debug("Streaming Bilibili {} at {} bps", trackInfo.identifier, stream.bandwidth());
+
+            try(PersistentHttpStream inputStream =
+                        new PersistentHttpStream(httpInterface, new URI(stream.url()), null))
+            {
+                processDelegate(new MpegAudioTrack(trackInfo, inputStream), executor);
+            }
+        }
+    }
+
+    @Override
+    protected AudioTrack makeShallowClone()
+    {
+        return new BilibiliAudioTrack(trackInfo, cid, sourceManager);
+    }
+
+    @Override
+    public AudioSourceManager getSourceManager()
+    {
+        return sourceManager;
+    }
+}

--- a/src/main/java/com/jagrosh/jmusicbot/audio/bilibili/BilibiliLink.java
+++ b/src/main/java/com/jagrosh/jmusicbot/audio/bilibili/BilibiliLink.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026 Arif Banai (arif-banai)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jagrosh.jmusicbot.audio.bilibili;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Parses user input into a Bilibili request descriptor.
+ *
+ * <p>This class performs no I/O, which keeps URL handling fully unit-testable.
+ * {@code b23.tv} short links cannot be resolved without a network round trip, so they
+ * are reported as {@link Kind#SHORT_LINK} for the source manager to expand.
+ *
+ * @author Arif Banai (arif-banai)
+ */
+public record BilibiliLink(Kind kind, String id, int page)
+{
+    public enum Kind { VIDEO, SEARCH, SHORT_LINK }
+
+    public static final String SEARCH_PREFIX = "bilisearch:";
+
+    private static final Pattern VIDEO_URL = Pattern.compile(
+            "^(?:https?://)?(?:www\\.|m\\.)?bilibili\\.com/video/"
+            + "((?:BV[0-9A-Za-z]{10})|(?:[Aa][Vv]\\d+))/?(?:\\?.*)?$");
+    private static final Pattern BARE_BV = Pattern.compile("^BV[0-9A-Za-z]{10}$");
+    private static final Pattern SHORT_URL = Pattern.compile(
+            "^(?:https?://)?b23\\.tv/[0-9A-Za-z]+/?(?:\\?.*)?$");
+    private static final Pattern PAGE_PARAM = Pattern.compile("[?&]p=(-?\\d+)");
+
+    /**
+     * Parses the given input.
+     *
+     * @param input raw user input, may be null
+     * @return the parsed link, or null if the input does not belong to Bilibili
+     */
+    public static BilibiliLink parse(String input)
+    {
+        if(input == null)
+            return null;
+
+        String trimmed = input.trim();
+        if(trimmed.isEmpty())
+            return null;
+
+        if(trimmed.regionMatches(true, 0, SEARCH_PREFIX, 0, SEARCH_PREFIX.length()))
+        {
+            String query = trimmed.substring(SEARCH_PREFIX.length()).trim();
+            return query.isEmpty() ? null : new BilibiliLink(Kind.SEARCH, query, 1);
+        }
+
+        if(SHORT_URL.matcher(trimmed).matches())
+            return new BilibiliLink(Kind.SHORT_LINK, trimmed, 1);
+
+        Matcher video = VIDEO_URL.matcher(trimmed);
+        if(video.matches())
+            return new BilibiliLink(Kind.VIDEO, normalizeId(video.group(1)), extractPage(trimmed));
+
+        if(BARE_BV.matcher(trimmed).matches())
+            return new BilibiliLink(Kind.VIDEO, trimmed, 1);
+
+        return null;
+    }
+
+    /**
+     * Lowercases the {@code av} prefix so ids compare equal regardless of input casing.
+     */
+    private static String normalizeId(String id)
+    {
+        return id.regionMatches(true, 0, "av", 0, 2) ? "av" + id.substring(2) : id;
+    }
+
+    /**
+     * Reads {@code ?p=N}, falling back to 1 for absent, unparseable, or non-positive
+     * values. A bad page number should not stop the video from playing.
+     */
+    private static int extractPage(String url)
+    {
+        Matcher matcher = PAGE_PARAM.matcher(url);
+        if(!matcher.find())
+            return 1;
+
+        try
+        {
+            int page = Integer.parseInt(matcher.group(1));
+            return page > 0 ? page : 1;
+        }
+        catch(NumberFormatException ignored)
+        {
+            return 1;
+        }
+    }
+}

--- a/src/main/java/com/jagrosh/jmusicbot/audio/bilibili/BilibiliResponseParser.java
+++ b/src/main/java/com/jagrosh/jmusicbot/audio/bilibili/BilibiliResponseParser.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2026 Arif Banai (arif-banai)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jagrosh.jmusicbot.audio.bilibili;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.sedmelluq.discord.lavaplayer.tools.FriendlyException;
+
+/**
+ * Converts Bilibili API responses into typed values.
+ *
+ * <p>Every method here is a pure function of its {@link JsonNode} input, so the whole
+ * class is tested offline against captured real responses.
+ *
+ * @author Arif Banai (arif-banai)
+ */
+public final class BilibiliResponseParser
+{
+    private BilibiliResponseParser() {}
+
+    /**
+     * Throws when the response carries a non-zero {@code code}.
+     *
+     * <p>Bilibili's own message is preserved, so users see "稿件不可见" rather than a
+     * numeric code they cannot act on.
+     */
+    public static void checkCode(JsonNode root)
+    {
+        int code = root.path("code").asInt(-1);
+        if(code == 0)
+            return;
+
+        String message = root.path("message").asText("unknown error");
+        throw new FriendlyException("Bilibili rejected the request: " + message + " (code " + code + ")",
+                FriendlyException.Severity.COMMON, null);
+    }
+
+    /**
+     * Reads video metadata, selecting the given 1-based page.
+     *
+     * <p>Out-of-range pages fall back to page 1 rather than failing, since a bad
+     * {@code ?p=} should not block playback of a video that exists.
+     */
+    public static BilibiliVideo parseView(JsonNode root, int page)
+    {
+        checkCode(root);
+        JsonNode data = root.path("data");
+        JsonNode pages = data.path("pages");
+
+        boolean hasPages = pages.isArray() && !pages.isEmpty();
+        int index = (hasPages && page >= 1 && page <= pages.size()) ? page - 1 : 0;
+        JsonNode selected = hasPages ? pages.get(index) : null;
+
+        long cid = selected != null ? selected.path("cid").asLong() : data.path("cid").asLong();
+        long seconds = selected != null ? selected.path("duration").asLong() : data.path("duration").asLong();
+
+        return new BilibiliVideo(
+                data.path("bvid").asText(),
+                cid,
+                buildTitle(data.path("title").asText(), selected, pages.size(), index),
+                data.path("owner").path("name").asText(),
+                seconds * 1000L,
+                data.path("pic").asText());
+    }
+
+    /**
+     * Qualifies the title with the part name when a video has several pages, so a queue
+     * of parts from the same video is readable.
+     */
+    private static String buildTitle(String title, JsonNode selected, int pageCount, int index)
+    {
+        if(selected == null || pageCount <= 1)
+            return title;
+
+        String part = selected.path("part").asText("");
+        if(part.isBlank() || part.equals(title))
+            return title + " - P" + (index + 1);
+
+        return title + " - P" + (index + 1) + " " + part;
+    }
+
+    /**
+     * Selects the best audio stream: the highest-bandwidth DASH entry when present,
+     * otherwise the progressive {@code durl} that older videos still return.
+     */
+    public static BilibiliAudioStream parseAudioStream(JsonNode root)
+    {
+        checkCode(root);
+        JsonNode data = root.path("data");
+
+        JsonNode audioList = data.path("dash").path("audio");
+        if(audioList.isArray() && !audioList.isEmpty())
+        {
+            JsonNode best = null;
+            for(JsonNode candidate : audioList)
+                if(best == null || candidate.path("bandwidth").asInt() > best.path("bandwidth").asInt())
+                    best = candidate;
+
+            return new BilibiliAudioStream(best.path("baseUrl").asText(),
+                    readUrlList(best.path("backupUrl")), best.path("bandwidth").asInt());
+        }
+
+        JsonNode durl = data.path("durl");
+        if(durl.isArray() && !durl.isEmpty())
+            return new BilibiliAudioStream(durl.get(0).path("url").asText(),
+                    readUrlList(durl.get(0).path("backup_url")), 0);
+
+        throw new FriendlyException("Bilibili returned no playable audio for this video",
+                FriendlyException.Severity.SUSPICIOUS, null);
+    }
+
+    /**
+     * Reads search results, skipping the ad and placeholder entries that carry no
+     * {@code bvid} and therefore cannot be played.
+     */
+    public static List<BilibiliVideo> parseSearch(JsonNode root)
+    {
+        checkCode(root);
+        List<BilibiliVideo> videos = new ArrayList<>();
+
+        for(JsonNode item : root.path("data").path("result"))
+        {
+            String bvid = item.path("bvid").asText("");
+            if(bvid.isBlank())
+                continue;
+
+            videos.add(new BilibiliVideo(
+                    bvid,
+                    0L,
+                    stripHighlight(item.path("title").asText()),
+                    item.path("author").asText(),
+                    parseDuration(item.path("duration").asText("")),
+                    normalizeThumbnail(item.path("pic").asText(""))));
+        }
+        return videos;
+    }
+
+    private static List<String> readUrlList(JsonNode node)
+    {
+        List<String> urls = new ArrayList<>();
+        for(JsonNode url : node)
+            urls.add(url.asText());
+        return urls;
+    }
+
+    /**
+     * Search titles wrap matched terms in {@code <em>} tags; the queue should show plain
+     * text.
+     */
+    private static String stripHighlight(String title)
+    {
+        return title.replaceAll("<[^>]+>", "");
+    }
+
+    /**
+     * Search results express duration as {@code m:ss} or {@code h:mm:ss}, unlike the view
+     * endpoint which returns seconds.
+     */
+    private static long parseDuration(String duration)
+    {
+        if(duration.isBlank())
+            return 0L;
+
+        long total = 0L;
+        for(String part : duration.split(":"))
+        {
+            try
+            {
+                total = total * 60 + Long.parseLong(part.trim());
+            }
+            catch(NumberFormatException e)
+            {
+                return 0L;
+            }
+        }
+        return total * 1000L;
+    }
+
+    /**
+     * Search thumbnails come back protocol-relative, e.g. {@code //i0.hdslb.com/...}.
+     */
+    private static String normalizeThumbnail(String pic)
+    {
+        return pic.startsWith("//") ? "https:" + pic : pic;
+    }
+}

--- a/src/main/java/com/jagrosh/jmusicbot/audio/bilibili/BilibiliVideo.java
+++ b/src/main/java/com/jagrosh/jmusicbot/audio/bilibili/BilibiliVideo.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 Arif Banai (arif-banai)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jagrosh.jmusicbot.audio.bilibili;
+
+/**
+ * Metadata for one playable Bilibili video page.
+ *
+ * <p>A {@code cid} of 0 means the page id is not yet known. Search results arrive without
+ * one, so tracks built from them resolve it at playback time using the {@code bvid}.
+ *
+ * @param bvid the video id, e.g. {@code BV1DTbv6xEHK}
+ * @param cid the page id, or 0 if not yet resolved
+ * @param title display title, already including the part name for multi-page videos
+ * @param author the uploader's name
+ * @param durationMs the length in milliseconds
+ * @param thumbnailUrl an absolute https URL
+ *
+ * @author Arif Banai (arif-banai)
+ */
+public record BilibiliVideo(String bvid, long cid, String title, String author,
+                            long durationMs, String thumbnailUrl)
+{
+}

--- a/src/main/java/com/jagrosh/jmusicbot/audio/bilibili/WbiSigner.java
+++ b/src/main/java/com/jagrosh/jmusicbot/audio/bilibili/WbiSigner.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2026 Arif Banai (arif-banai)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jagrosh.jmusicbot.audio.bilibili;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Implements Bilibili's WBI request signing.
+ *
+ * <p>Signed requests carry a {@code wts} timestamp and a {@code w_rid} MD5 digest. The
+ * digest key is derived by permuting the concatenation of two keys published by the
+ * {@code nav} endpoint through a fixed table.
+ *
+ * <p>MD5 comes from {@link MessageDigest}, which lives in {@code java.base}. That keeps
+ * the Docker image's jlink module list unchanged.
+ *
+ * @author Arif Banai (arif-banai)
+ */
+public final class WbiSigner
+{
+    /** Bilibili's fixed permutation table for deriving the mixin key. */
+    private static final int[] MIXIN_KEY_TABLE = {
+        46, 47, 18,  2, 53,  8, 23, 32, 15, 50, 10, 31, 58,  3, 45, 35,
+        27, 43,  5, 49, 33,  9, 42, 19, 29, 28, 14, 39, 12, 38, 41, 13,
+        37, 48,  7, 16, 24, 55, 40, 61, 26, 17,  0,  1, 60, 51, 30,  4,
+        22, 25, 54, 21, 56, 59,  6, 63, 57, 62, 11, 36, 20, 34, 44, 52
+    };
+
+    /** Characters Bilibili strips from parameter values before signing. */
+    private static final String EXCLUDED_CHARACTERS = "!'()*";
+
+    private static final int MIXIN_KEY_LENGTH = 32;
+
+    private WbiSigner() {}
+
+    /**
+     * Derives the signing key from the two keys published by the {@code nav} endpoint.
+     *
+     * @param imgKey the key taken from {@code wbi_img.img_url}
+     * @param subKey the key taken from {@code wbi_img.sub_url}
+     * @return a 32-character mixin key
+     */
+    public static String mixinKey(String imgKey, String subKey)
+    {
+        String raw = imgKey + subKey;
+        StringBuilder builder = new StringBuilder(MIXIN_KEY_LENGTH);
+
+        for(int index : MIXIN_KEY_TABLE)
+        {
+            if(builder.length() == MIXIN_KEY_LENGTH)
+                break;
+            if(index < raw.length())
+                builder.append(raw.charAt(index));
+        }
+        return builder.toString();
+    }
+
+    /**
+     * Extracts {@code <key>} from a {@code .../<key>.png} URL.
+     */
+    public static String keyFromUrl(String url)
+    {
+        String fileName = url.substring(url.lastIndexOf('/') + 1);
+        int dot = fileName.lastIndexOf('.');
+        return dot < 0 ? fileName : fileName.substring(0, dot);
+    }
+
+    /**
+     * Signs the given parameters.
+     *
+     * @param params the request parameters, excluding {@code wts} and {@code w_rid}
+     * @param mixinKey the key from {@link #mixinKey(String, String)}
+     * @param wtsSeconds the request timestamp in seconds
+     * @return a complete query string ending in {@code &w_rid=...}
+     */
+    public static String sign(Map<String, String> params, String mixinKey, long wtsSeconds)
+    {
+        Map<String, String> sorted = new TreeMap<>(params);
+        sorted.put("wts", Long.toString(wtsSeconds));
+
+        StringBuilder query = new StringBuilder();
+        for(Map.Entry<String, String> entry : sorted.entrySet())
+        {
+            if(query.length() > 0)
+                query.append('&');
+
+            query.append(encode(entry.getKey()))
+                 .append('=')
+                 .append(encode(strip(entry.getValue())));
+        }
+
+        return query + "&w_rid=" + md5(query + mixinKey);
+    }
+
+    private static String strip(String value)
+    {
+        StringBuilder builder = new StringBuilder(value.length());
+        for(int i = 0; i < value.length(); i++)
+        {
+            char c = value.charAt(i);
+            if(EXCLUDED_CHARACTERS.indexOf(c) < 0)
+                builder.append(c);
+        }
+        return builder.toString();
+    }
+
+    private static String encode(String value)
+    {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
+    }
+
+    private static String md5(String input)
+    {
+        try
+        {
+            byte[] digest = MessageDigest.getInstance("MD5")
+                    .digest(input.getBytes(StandardCharsets.UTF_8));
+
+            StringBuilder hex = new StringBuilder(digest.length * 2);
+            for(byte b : digest)
+                hex.append(Character.forDigit((b >> 4) & 0xF, 16))
+                   .append(Character.forDigit(b & 0xF, 16));
+
+            return hex.toString();
+        }
+        catch(NoSuchAlgorithmException e)
+        {
+            throw new IllegalStateException("MD5 is required for Bilibili WBI signing", e);
+        }
+    }
+}

--- a/src/main/java/com/jagrosh/jmusicbot/commands/v1/CommandFactory.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/v1/CommandFactory.java
@@ -76,6 +76,7 @@ public class CommandFactory {
                     new RemoveCmd(bot),
                     new SearchCmd(bot),
                     new SCSearchCmd(bot),
+                    new BiliSearchCmd(bot),
                     new SeekCmd(bot),
                     new ShuffleCmd(bot),
                     new SkipCmd(bot),

--- a/src/main/java/com/jagrosh/jmusicbot/commands/v1/music/BiliSearchCmd.java
+++ b/src/main/java/com/jagrosh/jmusicbot/commands/v1/music/BiliSearchCmd.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 Arif Banai (arif-banai)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jagrosh.jmusicbot.commands.v1.music;
+
+import com.jagrosh.jmusicbot.Bot;
+
+/**
+ * Searches Bilibili (哔哩哔哩) for a query and offers the results for selection.
+ *
+ * @author Arif Banai (arif-banai)
+ */
+public class BiliSearchCmd extends SearchCmd
+{
+    public BiliSearchCmd(Bot bot)
+    {
+        super(bot);
+        this.searchPrefix = "bilisearch:";
+        this.name = "bilisearch";
+        this.help = "searches Bilibili for a provided query";
+        this.aliases = bot.getConfig().getAliases(this.name);
+    }
+}

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -116,6 +116,7 @@ commands {
     queue = [ "list" ]
     remove = [ "delete" ]
     scsearch = []
+    bilisearch = [ "bsearch" ]
     search = [ "ytsearch" ]
     shuffle = []
     skip = [ "voteskip" ]

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -65,6 +65,7 @@ playback {
     beam = true
     getyarn = true
     nico = true
+    bilibili = true
     http = true
     local = true
   }

--- a/src/test/java/com/jagrosh/jmusicbot/integration/BilibiliLiveIntegrationTest.java
+++ b/src/test/java/com/jagrosh/jmusicbot/integration/BilibiliLiveIntegrationTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2026 Arif Banai (arif-banai)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jagrosh.jmusicbot.integration;
+
+import com.jagrosh.jmusicbot.audio.bilibili.BilibiliApiClient;
+import com.jagrosh.jmusicbot.audio.bilibili.BilibiliAudioSourceManager;
+import com.jagrosh.jmusicbot.audio.bilibili.BilibiliAudioStream;
+import com.jagrosh.jmusicbot.audio.bilibili.BilibiliVideo;
+import com.sedmelluq.discord.lavaplayer.tools.io.HttpInterface;
+import com.sedmelluq.discord.lavaplayer.tools.io.PersistentHttpStream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import java.net.URI;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Exercises the Bilibili source against the live API.
+ *
+ * <p>Disabled unless {@code BILIBILI_LIVE_TEST=1}, so CI stays offline and deterministic.
+ * Run with: {@code BILIBILI_LIVE_TEST=1 mvn test -Dtest=BilibiliLiveIntegrationTest}
+ *
+ * @author Arif Banai (arif-banai)
+ */
+@EnabledIfEnvironmentVariable(named = "BILIBILI_LIVE_TEST", matches = "1")
+@DisplayName("Bilibili Live API Integration")
+class BilibiliLiveIntegrationTest
+{
+    @Test
+    @DisplayName("searches, resolves metadata, and opens a readable audio stream")
+    void resolvesRealVideoEndToEnd() throws Exception
+    {
+        BilibiliAudioSourceManager manager = new BilibiliAudioSourceManager();
+
+        try(HttpInterface http = manager.getHttpInterface())
+        {
+            BilibiliApiClient client = manager.getApiClient();
+
+            List<BilibiliVideo> results = client.search(http, "周杰伦", 5);
+            assertFalse(results.isEmpty(), "search should return playable results");
+            assertTrue(results.stream().allMatch(v -> !v.bvid().isBlank()));
+
+            BilibiliVideo video = client.loadVideo(http, results.get(0).bvid(), 1);
+            assertTrue(video.cid() > 0, "view should yield a page id");
+            assertTrue(video.durationMs() > 0, "view should yield a duration");
+
+            BilibiliAudioStream stream = client.loadAudioStream(http, video.bvid(), video.cid());
+            assertTrue(stream.url().startsWith("http"), stream.url());
+
+            // Proves the Referer/User-Agent headers are actually reaching the CDN: without
+            // them Bilibili answers 403 and no bytes arrive.
+            try(PersistentHttpStream input = new PersistentHttpStream(http, new URI(stream.url()), null))
+            {
+                byte[] header = new byte[12];
+                assertEquals(12, input.read(header, 0, 12), "should read the container header");
+
+                String boxType = new String(header, 4, 4, java.nio.charset.StandardCharsets.US_ASCII);
+                assertEquals("ftyp", boxType, "Bilibili audio should be an MP4 container");
+            }
+        }
+        finally
+        {
+            manager.shutdown();
+        }
+    }
+
+    @Test
+    @DisplayName("resolves a multi-page video to the requested page only")
+    void resolvesRequestedPageOnly() throws Exception
+    {
+        BilibiliAudioSourceManager manager = new BilibiliAudioSourceManager();
+
+        try(HttpInterface http = manager.getHttpInterface())
+        {
+            BilibiliApiClient client = manager.getApiClient();
+            List<BilibiliVideo> results = client.search(http, "纪录片", 10);
+            assertFalse(results.isEmpty());
+
+            // Any video resolves page 1; a video with several pages gives page 2 a distinct cid.
+            BilibiliVideo page1 = client.loadVideo(http, results.get(0).bvid(), 1);
+            BilibiliVideo page2 = client.loadVideo(http, results.get(0).bvid(), 2);
+
+            assertTrue(page1.cid() > 0);
+            assertTrue(page2.cid() > 0);
+        }
+        finally
+        {
+            manager.shutdown();
+        }
+    }
+}

--- a/src/test/java/com/jagrosh/jmusicbot/unit/AudioSourceUnitTest.java
+++ b/src/test/java/com/jagrosh/jmusicbot/unit/AudioSourceUnitTest.java
@@ -54,7 +54,7 @@ class AudioSourceUnitTest {
             AudioSource[] platformSources = {
                 AudioSource.YOUTUBE, AudioSource.SOUNDCLOUD, AudioSource.BANDCAMP,
                 AudioSource.VIMEO, AudioSource.TWITCH, AudioSource.BEAM,
-                AudioSource.GETYARN, AudioSource.NICO
+                AudioSource.GETYARN, AudioSource.NICO, AudioSource.BILIBILI
             };
             
             // Catch-all sources that should be registered last
@@ -90,6 +90,22 @@ class AudioSourceUnitTest {
             
             assertTrue(soundcloudIndex < httpIndex,
                 "SoundCloud should appear before HTTP in the sorted list");
+        }
+
+        @Test
+        @DisplayName("BILIBILI is registered as a platform-specific source before HTTP")
+        void bilibiliIsPlatformSpecific() {
+            assertEquals("bilibili", AudioSource.BILIBILI.getConfigName());
+            assertTrue(AudioSource.BILIBILI.getRegistrationPriority()
+                            < AudioSource.HTTP.getRegistrationPriority(),
+                "Bilibili must be registered before the HTTP catch-all, or HTTP claims its URLs");
+        }
+
+        @Test
+        @DisplayName("BILIBILI resolves from its config name case-insensitively")
+        void bilibiliResolvesFromConfigName() {
+            assertEquals(Optional.of(AudioSource.BILIBILI), AudioSource.fromConfigName("bilibili"));
+            assertEquals(Optional.of(AudioSource.BILIBILI), AudioSource.fromConfigName("BiliBili"));
         }
 
         @Test

--- a/src/test/java/com/jagrosh/jmusicbot/unit/BotConfigUnitTest.java
+++ b/src/test/java/com/jagrosh/jmusicbot/unit/BotConfigUnitTest.java
@@ -424,6 +424,7 @@ class BotConfigUnitTest extends BaseConfigTest {
                   beam = false
                   getyarn = true
                   nico = true
+                  bilibili = true
                   http = true
                   local = true
                 }
@@ -436,8 +437,8 @@ class BotConfigUnitTest extends BaseConfigTest {
             
             Set<AudioSource> sources = config.getEnabledAudioSources();
             
-            // Should have 8 sources enabled (10 total - 2 disabled)
-            assertEquals(8, sources.size(), "Should have 8 sources enabled");
+            // Should have 9 sources enabled (11 total - 2 disabled)
+            assertEquals(9, sources.size(), "Should have 9 sources enabled");
             
             // Enabled sources
             assertTrue(config.isAudioSourceEnabled(AudioSource.YOUTUBE));
@@ -446,6 +447,7 @@ class BotConfigUnitTest extends BaseConfigTest {
             assertTrue(config.isAudioSourceEnabled(AudioSource.TWITCH));
             assertTrue(config.isAudioSourceEnabled(AudioSource.GETYARN));
             assertTrue(config.isAudioSourceEnabled(AudioSource.NICO));
+            assertTrue(config.isAudioSourceEnabled(AudioSource.BILIBILI));
             assertTrue(config.isAudioSourceEnabled(AudioSource.HTTP));
             assertTrue(config.isAudioSourceEnabled(AudioSource.LOCAL));
             
@@ -474,6 +476,7 @@ class BotConfigUnitTest extends BaseConfigTest {
                   beam = false
                   getyarn = false
                   nico = false
+                  bilibili = false
                   http = false
                   local = false
                 }
@@ -659,6 +662,7 @@ class BotConfigUnitTest extends BaseConfigTest {
                   beam = false
                   getyarn = false
                   nico = false
+                  bilibili = false
                   http = true
                   local = false
                 }

--- a/src/test/java/com/jagrosh/jmusicbot/unit/bilibili/BilibiliApiClientTest.java
+++ b/src/test/java/com/jagrosh/jmusicbot/unit/bilibili/BilibiliApiClientTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 Arif Banai (arif-banai)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jagrosh.jmusicbot.unit.bilibili;
+
+import com.jagrosh.jmusicbot.audio.bilibili.BilibiliApiClient;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("BilibiliApiClient Tests")
+class BilibiliApiClientTest
+{
+    private static final String MIXIN_KEY = "ea1db124af3c7062474693fa704f4ff8";
+
+    @Test
+    @DisplayName("sends a Referer, which Bilibili's CDN requires")
+    void definesReferer()
+    {
+        assertEquals("https://www.bilibili.com", BilibiliApiClient.REFERER);
+    }
+
+    @Test
+    @DisplayName("sends a browser User-Agent, which Bilibili's CDN requires")
+    void definesBrowserUserAgent()
+    {
+        assertTrue(BilibiliApiClient.USER_AGENT.contains("Mozilla/5.0"), BilibiliApiClient.USER_AGENT);
+    }
+
+    @Test
+    @DisplayName("builds a signed playurl query with the DASH parameters")
+    void buildsSignedPlayurlQuery()
+    {
+        String query = BilibiliApiClient.buildPlayurlQuery("BV1DTbv6xEHK", 40990605342L,
+                MIXIN_KEY, 1755400000L);
+
+        assertEquals("bvid=BV1DTbv6xEHK&cid=40990605342&fnval=16&fnver=0&fourk=1"
+                + "&wts=1755400000&w_rid=b2ccf4c580d6c55ccd9dbe3aa170907e", query);
+    }
+
+    @Test
+    @DisplayName("uses aid for av ids and bvid for BV ids")
+    void selectsIdParameter()
+    {
+        assertEquals("aid=170001", BilibiliApiClient.buildViewQuery("av170001"));
+        assertEquals("bvid=BV1DTbv6xEHK", BilibiliApiClient.buildViewQuery("BV1DTbv6xEHK"));
+    }
+
+    @Test
+    @DisplayName("builds an unsigned playurl query as the fallback when signing is unavailable")
+    void buildsUnsignedFallbackQuery()
+    {
+        String query = BilibiliApiClient.buildUnsignedPlayurlQuery("BV1DTbv6xEHK", 40990605342L);
+
+        assertTrue(query.contains("bvid=BV1DTbv6xEHK"), query);
+        assertTrue(query.contains("cid=40990605342"), query);
+        assertTrue(query.contains("fnval=16"), query);
+        assertFalse(query.contains("w_rid"), "the fallback must not claim to be signed");
+    }
+}

--- a/src/test/java/com/jagrosh/jmusicbot/unit/bilibili/BilibiliApiClientTest.java
+++ b/src/test/java/com/jagrosh/jmusicbot/unit/bilibili/BilibiliApiClientTest.java
@@ -55,8 +55,19 @@ class BilibiliApiClientTest
     @DisplayName("uses aid for av ids and bvid for BV ids")
     void selectsIdParameter()
     {
-        assertEquals("aid=170001", BilibiliApiClient.buildViewQuery("av170001"));
-        assertEquals("bvid=BV1DTbv6xEHK", BilibiliApiClient.buildViewQuery("BV1DTbv6xEHK"));
+        assertEquals("aid=170001", BilibiliApiClient.buildUnsignedViewQuery("av170001"));
+        assertEquals("bvid=BV1DTbv6xEHK", BilibiliApiClient.buildUnsignedViewQuery("BV1DTbv6xEHK"));
+    }
+
+    @Test
+    @DisplayName("signs the view query, which the plain endpoint's risk control now requires")
+    void buildsSignedViewQuery()
+    {
+        assertEquals("bvid=BV1DTbv6xEHK&wts=1755400000&w_rid=5f94615885f2ee37b38f22b141df7f76",
+                BilibiliApiClient.buildViewQuery("BV1DTbv6xEHK", MIXIN_KEY, 1755400000L));
+
+        assertEquals("aid=170001&wts=1755400000&w_rid=3549f09727df8b40a060137c8d36e2ba",
+                BilibiliApiClient.buildViewQuery("av170001", MIXIN_KEY, 1755400000L));
     }
 
     @Test

--- a/src/test/java/com/jagrosh/jmusicbot/unit/bilibili/BilibiliAudioSourceManagerTest.java
+++ b/src/test/java/com/jagrosh/jmusicbot/unit/bilibili/BilibiliAudioSourceManagerTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2026 Arif Banai (arif-banai)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jagrosh.jmusicbot.unit.bilibili;
+
+import com.jagrosh.jmusicbot.audio.bilibili.BilibiliAudioSourceManager;
+import com.jagrosh.jmusicbot.audio.bilibili.BilibiliAudioTrack;
+import com.sedmelluq.discord.lavaplayer.track.AudioReference;
+import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
+import com.sedmelluq.discord.lavaplayer.track.AudioTrackInfo;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("BilibiliAudioSourceManager Tests")
+class BilibiliAudioSourceManagerTest
+{
+    private BilibiliAudioSourceManager manager;
+
+    @BeforeEach
+    void setUp()
+    {
+        manager = new BilibiliAudioSourceManager();
+    }
+
+    @AfterEach
+    void tearDown()
+    {
+        manager.shutdown();
+    }
+
+    @Test
+    @DisplayName("reports the source name used in config and logs")
+    void reportsSourceName()
+    {
+        assertEquals("bilibili", manager.getSourceName());
+    }
+
+    @Test
+    @DisplayName("declines identifiers belonging to other sources without any network call")
+    void declinesForeignIdentifiers()
+    {
+        assertNull(manager.loadItem(null, new AudioReference("https://youtube.com/watch?v=abc", null)));
+        assertNull(manager.loadItem(null, new AudioReference("ytsearch:hello", null)));
+        assertNull(manager.loadItem(null, new AudioReference("scsearch:hello", null)));
+        assertNull(manager.loadItem(null, new AudioReference("some random text", null)));
+    }
+
+    @Test
+    @DisplayName("exposes an HTTP interface for the track to stream through")
+    void exposesHttpInterface()
+    {
+        assertNotNull(manager.getHttpInterface());
+        assertNotNull(manager.getApiClient());
+    }
+
+    @Test
+    @DisplayName("round-trips a track's cid through encode and decode")
+    void roundTripsTrackEncoding() throws Exception
+    {
+        AudioTrackInfo info = new AudioTrackInfo("Title", "Author", 1000L, "BV1DTbv6xEHK",
+                false, "https://www.bilibili.com/video/BV1DTbv6xEHK", "https://pic", null);
+        AudioTrack original = new BilibiliAudioTrack(info, 40990605342L, manager);
+
+        assertTrue(manager.isTrackEncodable(original));
+
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        manager.encodeTrack(original, new DataOutputStream(bytes));
+
+        AudioTrack decoded = manager.decodeTrack(info,
+                new DataInputStream(new ByteArrayInputStream(bytes.toByteArray())));
+
+        assertInstanceOf(BilibiliAudioTrack.class, decoded);
+        assertEquals(40990605342L, ((BilibiliAudioTrack) decoded).getCid(),
+                "the cid must survive a restart so queued tracks stay playable");
+    }
+
+    @Test
+    @DisplayName("a cloned track keeps its cid and source manager")
+    void clonesTrack()
+    {
+        AudioTrackInfo info = new AudioTrackInfo("Title", "Author", 1000L, "BV1DTbv6xEHK",
+                false, "https://www.bilibili.com/video/BV1DTbv6xEHK", "https://pic", null);
+        BilibiliAudioTrack original = new BilibiliAudioTrack(info, 12345L, manager);
+
+        AudioTrack clone = original.makeClone();
+
+        assertInstanceOf(BilibiliAudioTrack.class, clone);
+        assertEquals(12345L, ((BilibiliAudioTrack) clone).getCid());
+        assertSame(manager, clone.getSourceManager());
+    }
+}

--- a/src/test/java/com/jagrosh/jmusicbot/unit/bilibili/BilibiliLinkTest.java
+++ b/src/test/java/com/jagrosh/jmusicbot/unit/bilibili/BilibiliLinkTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2026 Arif Banai (arif-banai)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jagrosh.jmusicbot.unit.bilibili;
+
+import com.jagrosh.jmusicbot.audio.bilibili.BilibiliLink;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("BilibiliLink Parsing Tests")
+class BilibiliLinkTest
+{
+    @Test
+    @DisplayName("parses a standard video URL to page 1")
+    void parsesStandardVideoUrl()
+    {
+        BilibiliLink link = BilibiliLink.parse("https://www.bilibili.com/video/BV1DTbv6xEHK");
+        assertNotNull(link);
+        assertEquals(BilibiliLink.Kind.VIDEO, link.kind());
+        assertEquals("BV1DTbv6xEHK", link.id());
+        assertEquals(1, link.page());
+    }
+
+    @Test
+    @DisplayName("honours the ?p= page parameter")
+    void honoursPageParameter()
+    {
+        BilibiliLink link = BilibiliLink.parse("https://www.bilibili.com/video/BV1GFbk6LEVm?p=3");
+        assertEquals(3, link.page());
+        assertEquals("BV1GFbk6LEVm", link.id());
+    }
+
+    @Test
+    @DisplayName("defaults to page 1 when p is absent, zero, or negative")
+    void defaultsPageToOne()
+    {
+        assertEquals(1, BilibiliLink.parse("https://www.bilibili.com/video/BV1GFbk6LEVm?p=0").page());
+        assertEquals(1, BilibiliLink.parse("https://www.bilibili.com/video/BV1GFbk6LEVm?p=-2").page());
+        assertEquals(1, BilibiliLink.parse("https://www.bilibili.com/video/BV1GFbk6LEVm?p=abc").page());
+    }
+
+    @Test
+    @DisplayName("parses av ids and mobile/short host variants")
+    void parsesAvAndHostVariants()
+    {
+        assertEquals("av170001", BilibiliLink.parse("https://www.bilibili.com/video/av170001").id());
+        assertEquals("BV1DTbv6xEHK", BilibiliLink.parse("https://m.bilibili.com/video/BV1DTbv6xEHK").id());
+        assertEquals("BV1DTbv6xEHK", BilibiliLink.parse("bilibili.com/video/BV1DTbv6xEHK").id());
+    }
+
+    @Test
+    @DisplayName("parses a bare BV id")
+    void parsesBareBvId()
+    {
+        BilibiliLink link = BilibiliLink.parse("BV1DTbv6xEHK");
+        assertEquals(BilibiliLink.Kind.VIDEO, link.kind());
+        assertEquals("BV1DTbv6xEHK", link.id());
+    }
+
+    @Test
+    @DisplayName("parses a b23.tv short link as SHORT_LINK")
+    void parsesShortLink()
+    {
+        BilibiliLink link = BilibiliLink.parse("https://b23.tv/AbCdEfG");
+        assertEquals(BilibiliLink.Kind.SHORT_LINK, link.kind());
+        assertEquals("https://b23.tv/AbCdEfG", link.id());
+    }
+
+    @Test
+    @DisplayName("parses the bilisearch: prefix and trims the query")
+    void parsesSearchPrefix()
+    {
+        BilibiliLink link = BilibiliLink.parse("bilisearch:  周杰伦 稻香  ");
+        assertEquals(BilibiliLink.Kind.SEARCH, link.kind());
+        assertEquals("周杰伦 稻香", link.id());
+    }
+
+    @Test
+    @DisplayName("returns null for non-Bilibili input")
+    void returnsNullForForeignInput()
+    {
+        assertNull(BilibiliLink.parse("https://www.youtube.com/watch?v=dQw4w9WgXcQ"));
+        assertNull(BilibiliLink.parse("never gonna give you up"));
+        assertNull(BilibiliLink.parse(null));
+        assertNull(BilibiliLink.parse(""));
+        assertNull(BilibiliLink.parse("bilisearch:   "));
+    }
+}

--- a/src/test/java/com/jagrosh/jmusicbot/unit/bilibili/BilibiliResponseParserTest.java
+++ b/src/test/java/com/jagrosh/jmusicbot/unit/bilibili/BilibiliResponseParserTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2026 Arif Banai (arif-banai)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jagrosh.jmusicbot.unit.bilibili;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jagrosh.jmusicbot.audio.bilibili.BilibiliAudioStream;
+import com.jagrosh.jmusicbot.audio.bilibili.BilibiliResponseParser;
+import com.jagrosh.jmusicbot.audio.bilibili.BilibiliVideo;
+import com.sedmelluq.discord.lavaplayer.tools.FriendlyException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("BilibiliResponseParser Tests")
+class BilibiliResponseParserTest
+{
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static JsonNode fixture(String name) throws Exception
+    {
+        try(InputStream in = BilibiliResponseParserTest.class.getResourceAsStream("/bilibili/" + name))
+        {
+            assertNotNull(in, "missing fixture: " + name);
+            return MAPPER.readTree(in);
+        }
+    }
+
+    @Test
+    @DisplayName("parses metadata from a single-page video")
+    void parsesSinglePageVideo() throws Exception
+    {
+        BilibiliVideo video = BilibiliResponseParser.parseView(fixture("view-single-page.json"), 1);
+
+        assertFalse(video.bvid().isBlank());
+        assertTrue(video.cid() > 0);
+        assertFalse(video.title().isBlank());
+        assertFalse(video.author().isBlank());
+        assertTrue(video.durationMs() > 0, "duration should be in milliseconds");
+        assertTrue(video.thumbnailUrl().startsWith("http"));
+    }
+
+    @Test
+    @DisplayName("selects the requested page of a multi-page video")
+    void selectsRequestedPage() throws Exception
+    {
+        JsonNode root = fixture("view-multi-page.json");
+        BilibiliVideo first = BilibiliResponseParser.parseView(root, 1);
+        BilibiliVideo third = BilibiliResponseParser.parseView(root, 3);
+
+        assertNotEquals(first.cid(), third.cid(), "each page has its own cid");
+        assertTrue(third.title().contains("P3"), "page title should identify the part: " + third.title());
+    }
+
+    @Test
+    @DisplayName("falls back to page 1 when the page is out of range")
+    void fallsBackToFirstPage() throws Exception
+    {
+        JsonNode root = fixture("view-multi-page.json");
+        assertEquals(BilibiliResponseParser.parseView(root, 1).cid(),
+                     BilibiliResponseParser.parseView(root, 999).cid());
+    }
+
+    @Test
+    @DisplayName("picks the highest-bandwidth DASH audio stream")
+    void picksHighestBandwidthAudio() throws Exception
+    {
+        JsonNode root = fixture("playurl-dash.json");
+        BilibiliAudioStream stream = BilibiliResponseParser.parseAudioStream(root);
+
+        int highest = 0;
+        for(JsonNode audio : root.path("data").path("dash").path("audio"))
+            highest = Math.max(highest, audio.path("bandwidth").asInt());
+
+        assertEquals(highest, stream.bandwidth(), "must select the best available bitrate");
+        assertTrue(stream.url().startsWith("http"));
+        assertNotNull(stream.backupUrls());
+    }
+
+    @Test
+    @DisplayName("parses search results and skips entries without a bvid")
+    void parsesSearchResults() throws Exception
+    {
+        List<BilibiliVideo> results = BilibiliResponseParser.parseSearch(fixture("search-video.json"));
+
+        assertFalse(results.isEmpty());
+        assertTrue(results.stream().noneMatch(v -> v.bvid() == null || v.bvid().isBlank()),
+                "ad/placeholder entries must be filtered out");
+        assertTrue(results.stream().noneMatch(v -> v.title().contains("<em")),
+                "search titles must have their HTML highlight tags stripped");
+        assertTrue(results.stream().anyMatch(v -> v.durationMs() > 0),
+                "m:ss durations must be converted to milliseconds");
+        assertTrue(results.stream().allMatch(v -> v.thumbnailUrl().startsWith("http")),
+                "protocol-relative thumbnails must be normalized");
+    }
+
+    @Test
+    @DisplayName("throws a FriendlyException carrying Bilibili's message on an error code")
+    void throwsOnErrorCode() throws Exception
+    {
+        JsonNode root = fixture("view-error-notfound.json");
+        FriendlyException thrown = assertThrows(FriendlyException.class,
+                () -> BilibiliResponseParser.checkCode(root));
+        assertTrue(thrown.getMessage().contains("啥都木有"), thrown.getMessage());
+    }
+
+    @Test
+    @DisplayName("accepts a successful response")
+    void acceptsSuccess() throws Exception
+    {
+        assertDoesNotThrow(() -> BilibiliResponseParser.checkCode(fixture("view-single-page.json")));
+    }
+
+    @Test
+    @DisplayName("reports a clear error when a response carries no playable audio")
+    void reportsMissingAudio() throws Exception
+    {
+        JsonNode empty = MAPPER.readTree("{\"code\":0,\"data\":{}}");
+        FriendlyException thrown = assertThrows(FriendlyException.class,
+                () -> BilibiliResponseParser.parseAudioStream(empty));
+        assertTrue(thrown.getMessage().toLowerCase().contains("audio"), thrown.getMessage());
+    }
+
+    @Test
+    @DisplayName("falls back to the progressive durl stream when no DASH audio exists")
+    void fallsBackToDurl() throws Exception
+    {
+        JsonNode durlOnly = MAPPER.readTree(
+                "{\"code\":0,\"data\":{\"durl\":[{\"url\":\"https://cdn.example/x.mp4\","
+                + "\"backup_url\":[\"https://backup.example/x.mp4\"]}]}}");
+
+        BilibiliAudioStream stream = BilibiliResponseParser.parseAudioStream(durlOnly);
+
+        assertEquals("https://cdn.example/x.mp4", stream.url());
+        assertEquals(List.of("https://backup.example/x.mp4"), stream.backupUrls());
+    }
+}

--- a/src/test/java/com/jagrosh/jmusicbot/unit/bilibili/WbiSignerTest.java
+++ b/src/test/java/com/jagrosh/jmusicbot/unit/bilibili/WbiSignerTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2026 Arif Banai (arif-banai)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jagrosh.jmusicbot.unit.bilibili;
+
+import com.jagrosh.jmusicbot.audio.bilibili.WbiSigner;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("WbiSigner Tests")
+class WbiSignerTest
+{
+    private static final String IMG_KEY = "7cd084941338484aae1ad9425b84077c";
+    private static final String SUB_KEY = "4932caff0ff746eab6f01bf08b70ac45";
+    private static final String MIXIN_KEY = "ea1db124af3c7062474693fa704f4ff8";
+
+    @Test
+    @DisplayName("derives the mixin key from real key material")
+    void derivesMixinKey()
+    {
+        assertEquals(MIXIN_KEY, WbiSigner.mixinKey(IMG_KEY, SUB_KEY));
+    }
+
+    @Test
+    @DisplayName("mixin key is always 32 characters")
+    void mixinKeyLength()
+    {
+        assertEquals(32, WbiSigner.mixinKey(IMG_KEY, SUB_KEY).length());
+    }
+
+    @Test
+    @DisplayName("extracts the key from a wbi image URL")
+    void extractsKeyFromUrl()
+    {
+        assertEquals(IMG_KEY, WbiSigner.keyFromUrl("https://i0.hdslb.com/bfs/wbi/" + IMG_KEY + ".png"));
+    }
+
+    @Test
+    @DisplayName("signs playurl parameters to the expected w_rid")
+    void signsPlayurlParameters()
+    {
+        Map<String, String> params = new LinkedHashMap<>();
+        params.put("fourk", "1");
+        params.put("bvid", "BV1DTbv6xEHK");
+        params.put("cid", "40990605342");
+        params.put("fnval", "16");
+        params.put("fnver", "0");
+
+        String query = WbiSigner.sign(params, MIXIN_KEY, 1755400000L);
+
+        assertEquals("bvid=BV1DTbv6xEHK&cid=40990605342&fnval=16&fnver=0&fourk=1"
+                + "&wts=1755400000&w_rid=b2ccf4c580d6c55ccd9dbe3aa170907e", query);
+    }
+
+    @Test
+    @DisplayName("signs a CJK search query, encoding spaces as plus")
+    void signsSearchQuery()
+    {
+        Map<String, String> params = new LinkedHashMap<>();
+        params.put("search_type", "video");
+        params.put("keyword", "周杰伦 稻香");
+        params.put("page", "1");
+
+        String query = WbiSigner.sign(params, MIXIN_KEY, 1755400000L);
+
+        assertTrue(query.endsWith("&w_rid=6d3769134fbbf27529071cfd988de7fb"), query);
+        assertTrue(query.contains("keyword=%E5%91%A8%E6%9D%B0%E4%BC%A6+%E7%A8%BB%E9%A6%99"), query);
+    }
+
+    @Test
+    @DisplayName("strips the characters Bilibili excludes from signed values")
+    void stripsExcludedCharacters()
+    {
+        Map<String, String> raw = new LinkedHashMap<>();
+        raw.put("keyword", "a!b'c(d)e*f");
+        Map<String, String> clean = new LinkedHashMap<>();
+        clean.put("keyword", "abcdef");
+
+        assertEquals(WbiSigner.sign(clean, MIXIN_KEY, 1755400000L),
+                WbiSigner.sign(raw, MIXIN_KEY, 1755400000L));
+    }
+}


### PR DESCRIPTION
### This pull request...
  - [ ] Fixes a bug
  - [x] Introduces a new feature
  - [ ] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description

First of all, thank you for taking over this project and continuing to maintain it! My friends and I really love this bot.

This PR adds **Bilibili (哔哩哔哩)** as a built-in audio source, so the bot can play audio from Bilibili videos by URL or keyword search — handy for communities whose listening happens largely outside YouTube.

What it does:

- `play` accepts Bilibili video URLs (`www.bilibili.com/video/BV…`, bare `BV`/`av` ids) and `b23.tv` short links; no Bilibili account or API key needed.
- A new `bilisearch` command (alias `bsearch`) searches by keyword and offers results through the same selection menu as `scsearch`.
- Multi-page (分P) videos resolve to exactly the part named by `?p=` (part 1 otherwise) — never expanded into a playlist.
- Registered behind the config toggle `playback.audioSources.bilibili`, so it can be disabled like any other source.

How it's implemented:

- A native lavaplayer `AudioSourceManager` in `audio/bilibili/` — **zero new Maven dependencies**, no yt-dlp/ffmpeg or external binaries; ships inside the shaded jar.
- Metadata resolves at load time; the CDN stream URL resolves lazily in `process()`, because Bilibili's CDN URLs expire after ~120 minutes and tracks can sit in queues longer than that.
- Playurl requests prefer the WBI-signed endpoint and fall back to the unsigned one if signing fails, so a future WBI change degrades gracefully instead of breaking playback.
- CDN requests carry the `Referer`/`User-Agent` headers Bilibili requires (verified by an opt-in live test asserting real bytes arrive).
- Pure logic (link parsing, WBI signing, JSON parsing) is separated from I/O and unit-tested offline against captured responses; the live integration test is env-gated (`BILIBILI_LIVE_TEST=1`) and stays off in CI.

### Purpose

Bilibili is one of the largest video platforms in the world, and a lot of audio content lives only there. This makes JMusicBot work out of the box for listeners outside YouTube's orbit, without external tools or forks.

### Relevant Issue(s)

None — proposing as a new feature.
