### PR TITLE
fix: restore YouTube playback (remote cipher + TV client User-Agent)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,19 @@
             <name>Lavalink Repository</name>
             <url>https://maven.lavalink.dev/releases</url>
         </repository>
+        <!-- Snapshots: youtube-source ships fixes here well ahead of tagged releases,
+             and YouTube breakages routinely need them. See youtube-source.version. -->
+        <repository>
+            <id>lavalinkSnapshots</id>
+            <name>Lavalink Snapshot Repository</name>
+            <url>https://maven.lavalink.dev/snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
         <repository>
             <id>chew</id>
             <name>m2-chew</name>
@@ -587,7 +600,10 @@
         <jdave.version>0.1.7</jdave.version>
         <udpqueue.version>0.2.12</udpqueue.version>
         <lavaplayer.version>2.2.7</lavaplayer.version>
-        <youtube-source.version>1.18.1</youtube-source.version>
+        <!-- Pinned to a main-branch snapshot: the TV client's Cobalt User-Agent is rejected by
+             YouTube ("The page needs to be reloaded"), fixed by b33460b3 which is in no release
+             yet (1.18.2 predates it). See youtube-source#226 and #240. -->
+        <youtube-source.version>f45bbb7aebfcbc1c553769e04af6cd43afa8b7c3-SNAPSHOT</youtube-source.version>
         <logback.version>1.5.25</logback.version>
         <typesafe-config.version>1.4.3</typesafe-config.version>
         <jsoup.version>1.22.1</jsoup.version>

--- a/src/main/java/com/jagrosh/jmusicbot/audio/AudioSource.java
+++ b/src/main/java/com/jagrosh/jmusicbot/audio/AudioSource.java
@@ -232,7 +232,7 @@ public enum AudioSource
         final Logger logger = LoggerFactory.getLogger(AudioSource.class);
         
         boolean useOauth = config.useYouTubeOauth();
-        YoutubeSourceOptions options = buildYoutubeOptions(config);
+        YoutubeSourceOptions options = buildYoutubeOptions();
         Client[] clients = buildYoutubeClients(useOauth);
 
         YoutubeAudioSourceManager yt = new YoutubeAudioSourceManager(options, clients);
@@ -247,18 +247,22 @@ public enum AudioSource
     
     /**
      * Builds YouTube source options.
+     *
+     * <p>The remote cipher server is always enabled, independent of OAuth. youtube-source no
+     * longer maintains local signature extraction, so {@code LocalSignatureCipherManager}
+     * fails against current YouTube player scripts ("must find sig function") whether or not
+     * OAuth is in use. Deciphering has to be offloaded to a cipher server.
+     *
+     * @see <a href="https://github.com/lavalink-devs/youtube-source/issues/240">youtube-source#240</a>
      */
-    private static YoutubeSourceOptions buildYoutubeOptions(BotConfig config)
+    private static YoutubeSourceOptions buildYoutubeOptions()
     {
         YoutubeSourceOptions options = new YoutubeSourceOptions()
                 .setAllowSearch(true)
                 .setAllowDirectVideoIds(true)
                 .setAllowDirectPlaylistIds(true);
         
-        if (config.useYouTubeOauth())
-        {
-            options.setRemoteCipher("https://cipher.kikkia.dev/", null, "jmusicbot");
-        }
+        options.setRemoteCipher("https://cipher.kikkia.dev/", null, "jmusicbot");
         
         return options;
     }

--- a/src/test/java/com/jagrosh/jmusicbot/unit/AudioSourceOAuthTest.java
+++ b/src/test/java/com/jagrosh/jmusicbot/unit/AudioSourceOAuthTest.java
@@ -17,6 +17,7 @@ package com.jagrosh.jmusicbot.unit;
 
 import com.jagrosh.jmusicbot.BotConfig;
 import dev.lavalink.youtube.YoutubeAudioSourceManager;
+import dev.lavalink.youtube.YoutubeSourceOptions;
 import dev.lavalink.youtube.clients.skeleton.Client;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -276,18 +277,18 @@ class AudioSourceOAuthTest {
         }
 
         @Test
-        @DisplayName("YouTube options include remote cipher when OAuth is enabled")
-        void youtubeOptionsIncludeRemoteCipherForOAuth() throws Exception {
+        @DisplayName("YouTube options always include the remote cipher, regardless of OAuth")
+        void youtubeOptionsAlwaysIncludeRemoteCipher() throws Exception {
             Method buildOptions = getBuildYoutubeOptionsMethod();
             
-            BotConfig mockConfig = createMockConfig(true, 10);
+            YoutubeSourceOptions options = (YoutubeSourceOptions) buildOptions.invoke(null);
             
-            // We can't easily verify the internal state of YoutubeSourceOptions,
-            // but we can verify the method completes without throwing
-            assertDoesNotThrow(() -> {
-                Object options = buildOptions.invoke(null, mockConfig);
-                assertNotNull(options, "Should return options for OAuth mode");
-            });
+            assertNotNull(options, "Should return options");
+            assertEquals("https://cipher.kikkia.dev/", options.getRemoteCipherUrl(),
+                "Remote cipher must always be configured; youtube-source no longer maintains "
+                    + "local signature extraction, so deciphering has to be offloaded");
+            assertEquals("jmusicbot", options.getRemoteCipherUserAgent(),
+                "Remote cipher user agent should identify the bot");
         }
         
         private Method getBuildYoutubeClientsMethod() throws NoSuchMethodException {
@@ -299,7 +300,7 @@ class AudioSourceOAuthTest {
         
         private Method getBuildYoutubeOptionsMethod() throws NoSuchMethodException {
             Class<?> audioSourceClass = com.jagrosh.jmusicbot.audio.AudioSource.class;
-            Method method = audioSourceClass.getDeclaredMethod("buildYoutubeOptions", BotConfig.class);
+            Method method = audioSourceClass.getDeclaredMethod("buildYoutubeOptions");
             method.setAccessible(true);
             return method;
         }


### PR DESCRIPTION
### This pull request...
  - [x] Fixes a bug
  - [ ] Introduces a new feature
  - [ ] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description

YouTube playback is currently broken for every track. The bot joins the voice channel, the
track resolves, and then playback dies immediately with `AllClientsFailedException`, so the
bot leaves as though the queue had emptied. This is issue #80.

There are two independent causes. Fixing either one alone is not enough.

**1. Signature deciphering (`AudioSource.java`)**

```
Client [MWEB] failed: Must find sig function from script: /s/player/e937390a/player_embed.vflset/en_US/base.js
Client [WEB]  failed: No supported audio streams available, available types:
```

youtube-source no longer maintains local signature extraction. From the maintainer in
lavalink-devs/youtube-source#240:

> Signature cipher extraction is expected to fail. This is no longer managed within the
> source and you really ought to be using a remote cipher server (refer to README.)

We already configure a remote cipher server, but only inside `if (config.useYouTubeOauth())`.
Upstream these are two independent settings — the remote cipher has nothing to do with OAuth —
so an operator who has not enabled OAuth gets no cipher server and cannot play anything. This
PR sets it unconditionally.

**2. TV client User-Agent (`pom.xml`)**

```
Client [TVHTML5]        failed: The page needs to be reloaded.
Client [TVHTML5_SIMPLY] failed: Sign in to confirm you're not a bot
```

Around 2026-08-18 YouTube began rejecting Cobalt-family User-Agents on the TVHTML5 player
endpoint, answering `UNPLAYABLE` / "The page needs to be reloaded" regardless of
`clientVersion`, `signatureTimestamp` or `params`. This is
lavalink-devs/youtube-source#226, where it was isolated to the User-Agent alone by controlled
reproduction; a PlayStation 4 identity is accepted and returns 27 formats.

`Tv` is the only OAuth-capable playback client we register, so once OAuth is on this failure
takes out playback entirely.

The fix is lavalink-devs/youtube-source@b33460b3, a one-line User-Agent change in `Tv.java`.
**No release carries it** — 1.18.2 was tagged 2026-07-27, before the YouTube change — so this
pins the main-branch snapshot `f45bbb7a` instead, which also picks up the client version bump
to 21.02.35 (#231) and the `contentLength` recovery fix (#235).

This supersedes #71: bumping to 1.18.2 does not help, and #240 reports the same failure on
1.18.2.

### Purpose

Restores YouTube playback. Verified end to end on a live bot (Raspberry Pi, `docker run`,
`eclipse-temurin:25-jre-noble`, OAuth enabled): the same query that failed before the change

```
[ERROR] [AudioHandler]: Track ZZY7os9KjwQ has failed to play
        (yts.version: 1.18.1) All clients failed to load the item.
```

now plays, with the native audio decoders actually loading rather than the bot leaving:

```
[INFO] [MusicService]: Track added to queue: ...
[INFO] [NativeLibraryLoader]: Native library libmpg123-0: loading with filter ...
[INFO] [NativeLibraryLoader]: Native library connector: successfully loaded.
[INFO] [NativeLibraryLoader]: Native library udpqueue: successfully loaded.
```

No `AllClientsFailedException`, and `TVHTML5_SIMPLY` is never reached because `Tv` now
succeeds first.

### Testing

- `mvn -B verify` — 664 unit tests and 43 integration tests pass.
- `AudioSourceOAuthTest` previously asserted only that `buildYoutubeOptions` did not throw.
  It now asserts `getRemoteCipherUrl()` and `getRemoteCipherUserAgent()` directly, so the
  coupling this PR removes cannot silently return.
- Confirmed the shaded jar actually carries the fix: `Tv.class` contains the PlayStation 4
  User-Agent and no longer contains the Cobalt string.

### A note on the snapshot pin

`f45bbb7a...-SNAPSHOT` is pinned to an exact commit hash, so it resolves reproducibly and
does not drift as `main` advances. It should be replaced with a tagged release as soon as one
including b33460b3 ships. Given how often YouTube breaks this dependency, it may be worth
keeping the snapshot repository declaration in `pom.xml` regardless.

### Relevant Issue(s)

Closes #80
Refs #71, lavalink-devs/youtube-source#226, lavalink-devs/youtube-source#240
